### PR TITLE
CAB-3797: Upgrade Atlantis to v10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM runatlantis/atlantis:v0.9.0
+FROM runatlantis/atlantis:v0.10.0
 
 COPY credentials.sh /usr/local/bin/credentials.sh
 RUN chmod +x /usr/local/bin/credentials.sh
@@ -12,8 +12,8 @@ RUN curl -L https://github.com/gruntwork-io/terragrunt/releases/download/v0.18.7
   && echo "3a45138e77fb41e0884b9491c67dcdeacd06418cd10a1e16ea0cc03976f1b288  /usr/local/bin/terragrunt-0.18" \
   | sha256sum -c
 
-RUN curl -L https://github.com/gruntwork-io/terragrunt/releases/download/v0.19.23/terragrunt_linux_amd64 -o /usr/local/bin/terragrunt-0.19 \
-  && echo "affff017c8a51843c3c0923c38bcf4bdaddbaa8dcb50dd7c089e4e08b0093874  /usr/local/bin/terragrunt-0.19" \
+RUN curl -L https://github.com/gruntwork-io/terragrunt/releases/download/v0.20.3/terragrunt_linux_amd64 -o /usr/local/bin/terragrunt-0.20 \
+  && echo "6fca4db39a191ee898a38fce201936324c6cf84bd3ba0fce8ecbddbdfc25d82a  /usr/local/bin/terragrunt-0.20" \
   | sha256sum -c
 
 


### PR DESCRIPTION
- UPGRADE TATLANTIS TO V0.10.0
- UPGRADE TERRAGRUNT TO V0.20.3